### PR TITLE
* index.erb : Preserve carriage returns

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -24,6 +24,7 @@ blockquote p {
   line-height: 1.55;
   font-weight: normal;
   margin-bottom: .4em;
+  white-space: pre;
 }
 blockquote small {
   font-size: 18px;


### PR DESCRIPTION
Some of those quotes contain carriage returns. To protect the beauty of the genuine haikus, this patch preserves white spaces.
